### PR TITLE
Fix import statement in index.js

### DIFF
--- a/markdown-editor/src/pages/index.js
+++ b/markdown-editor/src/pages/index.js
@@ -9,7 +9,6 @@ Create a basic markdown editor in Next.js with the following features:
 - The markdown text and resulting HTML should be saved in the component's state and updated in real time 
 */
 
-// import react markdown package
 import ReactMarkdown from 'react-markdown';
 import { useState } from 'react';
 import styled from 'styled-components';


### PR DESCRIPTION
This pull request includes a minor change to the `markdown-editor/src/pages/index.js` file in the markdown editor project. The change involves removing a comment line about importing the react markdown package, which is unnecessary because the import statement that follows is self-explanatory.